### PR TITLE
Do not generate new idmap if an idmap for an id type already exists

### DIFF
--- a/classes/idmap.php
+++ b/classes/idmap.php
@@ -113,10 +113,10 @@ class idmap implements Countable {
 
     /** Verify whether the provided id can be found in the ids of the idmap.
      *
-     * @param int|string $originalid
+     * @param int $originalid
      * @return bool whether the original id exists
      */
-    public function has_original_id(int|string $originalid): bool {
+    public function has_original_id(int $originalid): bool {
         return in_array($originalid, $this->originalids);
     }
 
@@ -170,7 +170,7 @@ class idmap implements Countable {
     /**
      * Getter for original ids
      *
-     * @return int[]|string[] originalids
+     * @return int[] originalids
      */
     public function get_originalids() : array {
         return $this->originalids;

--- a/classes/model_version.php
+++ b/classes/model_version.php
@@ -245,6 +245,8 @@ class model_version {
             if (empty($dataset)) { // Only if gathering data on site can we find related data.
                 $version->gather_related_data();
             }
+        } catch(Exception $e) {
+            $version->register_error($e);
         } finally {
             $version->finish();
             return $version;
@@ -458,11 +460,13 @@ class model_version {
 
             $evidence = $this->add('related_data_anonymized', $options);
 
+            $evidences[] = $evidence; // Store the evidence for anonymizing it later.
+
             // Create idmaps.
             $notanonymizeddata = $evidence->get_raw_data();
-            $this->idmaps[$relatedtablename] = related_data_helper::create_idmap_from_related_data($notanonymizeddata);
-
-            $evidences[] = $evidence; // Store the evidence for anonymizing it later.
+            if (!isset($this->idmaps[$relatedtablename])) {
+                $this->idmaps[$relatedtablename] = related_data_helper::create_idmap_from_related_data($notanonymizeddata);
+            }
         }
 
         // Anonymize the related data. We need ALL idmaps for that.


### PR DESCRIPTION
fixes #34 
fixes #36 

I fixed the bug by adding a condition to the creation of idmaps for related tables. A new idmap is only created, if no idmap for this id type (e.g. "user", "user_enrolment") does not exist yet.

I also made sure that if an exception occurs within model version creation, an error is registered for the version.

Finally, I also cleaned up the id types in the idmap class.